### PR TITLE
Fix for dateRangeinWords: Fix identification of date range matching exactly t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## 0.2.6 - 2018-04-24
+
+-   `dateRangeinWorkds` helper
+    - Fix identification of date range matching exactly the last week because of starting the week on Sunday instead of Monday.
+
+
 ## 0.2.6 - 2018-04-24
 
 -   `money` helper

--- a/lib/helpers/dateRangeInWords.js
+++ b/lib/helpers/dateRangeInWords.js
@@ -62,16 +62,12 @@ function _dateRangeCoversExclusivelyOneEntireMonth(dateRange) {
 }
 
 function _dateRangeCoversExclusivelyOneEntireWeek(dateRange) {
-    if (!dateRange.moment.start.isSame(dateRange.moment.end, 'week')) {
-        return false;
-    }
-
-    return dateRange.moment.start.date() === dateRange.moment.end.clone().startOf('week').date()
-        && dateRange.moment.end.date() === dateRange.moment.end.clone().endOf('week').date();
+    return dateRange.moment.start.isSame(dateRange.moment.start.clone().startOf('isoWeek'), 'day')
+        && dateRange.moment.end.diff(dateRange.moment.start, 'days') === 6;
 }
 
 function _dateInLastWeek(date) {
-    return moment().tz(date.tz()).subtract(1, 'week').isSame(date, 'week');
+    return moment().tz(date.tz()).startOf('isoWeek').subtract(1, 'week').isSame(date, 'isoWeek');
 }
 
 function _addPreposition(text, preposition) {


### PR DESCRIPTION
-   `dateRangeinWorkds` helper
    - Fix identification of date range matching exactly the last week because of starting the week on Sunday instead of Monday.